### PR TITLE
Return a helpful error message when login fails

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,9 +70,7 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - durationcheck # check for two durations multiplied together
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
     - exhaustive # check exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers
     - gochecknoinits # Checks that no init functions are present in Go code
     - goconst # Finds repeated strings that could be replaced by a constant

--- a/pkg/box/client.go
+++ b/pkg/box/client.go
@@ -88,6 +88,7 @@ func RequestAccessToken(ctx context.Context, clientID string, clientSecret strin
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, err := io.ReadAll(resp.Body)
@@ -96,8 +97,6 @@ func RequestAccessToken(ctx context.Context, clientID string, clientSecret strin
 		}
 		return "", fmt.Errorf("failed to get access token: %s status: %s", string(body), resp.Status)
 	}
-
-	defer resp.Body.Close()
 
 	var res struct {
 		AccessToken string `json:"access_token"`

--- a/pkg/box/client.go
+++ b/pkg/box/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -67,7 +68,6 @@ func RequestAccessToken(ctx context.Context, clientID string, clientSecret strin
 	if err != nil {
 		return "", err
 	}
-
 	authUrl := fmt.Sprint(baseUrl, "/oauth2/token")
 	data := url.Values{}
 	data.Add("client_id", clientID)
@@ -87,6 +87,14 @@ func RequestAccessToken(ctx context.Context, clientID string, clientSecret strin
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("failed to get access token: %s status: %s", string(body), resp.Status)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
When the user did not setup the box app correctly or used invalid credentials the Box API returns a helpful error message but we are not showing it to the user.

```
connector","error":"box-connector: failed to get token: failed to get access token: {\"error\":\"invalid_client\",\"error_description\":\"The client credentials are invalid\"} status: 400 Bad Request"}
box-connector: failed to get token: failed to get access token: {"error":"invalid_client","error_description":"The client credentials are invalid"} status: 400 Bad Request
```

Before it wouldn't error at all, it assume authentication succeeded and would try to authenticate with an empty string access token and fail later with an unhelpful error.