### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-box/main.go
+++ b/cmd/baton-box/main.go
@@ -44,7 +44,7 @@ func main() {
 func getConnector(ctx context.Context, c *cfg.Box) (types.ConnectorServer, error) {
 	l := ctxzap.Extract(ctx)
 
-	cb, err := connector.New(ctx, c.BoxClientId, c.BoxClientSecret, c.EnterpriseId)
+	cb, err := connector.New(ctx, c.BoxClientId, c.BoxClientSecret, c.EnterpriseId, c.BaseUrl)
 	if err != nil {
 		l.Error("error creating box connector", zap.Error(err))
 		return nil, err

--- a/pkg/box/client.go
+++ b/pkg/box/client.go
@@ -17,13 +17,14 @@ import (
 type Client struct {
 	httpClient *http.Client
 	token      string
+	baseURL    string
 }
 
 const (
-	baseUrl       = "https://api.box.com"
-	defaultOffset = 0
-	defaultLimit  = 200
-	errorType     = "error"
+	defaultBaseURL = "https://api.box.com"
+	defaultOffset  = 0
+	defaultLimit   = 200
+	errorType      = "error"
 )
 
 type paginationData struct {
@@ -44,10 +45,14 @@ var ErrorResponse struct {
 	Status    int64  `json:"status"`
 }
 
-func NewClient(httpClient *http.Client, token string) *Client {
+func NewClient(httpClient *http.Client, token string, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
 	return &Client{
 		httpClient: httpClient,
 		token:      token,
+		baseURL:    baseURL,
 	}
 }
 
@@ -63,12 +68,15 @@ func paginationQuery(offset int, limit int) url.Values {
 }
 
 // RequestAccessToken creates bearer token needed to use the Box API.
-func RequestAccessToken(ctx context.Context, clientID string, clientSecret string, enterpriseId string) (string, error) {
+func RequestAccessToken(ctx context.Context, clientID string, clientSecret string, enterpriseId string, baseURL string) (string, error) {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return "", err
 	}
-	authUrl := fmt.Sprint(baseUrl, "/oauth2/token")
+	authUrl := fmt.Sprint(baseURL, "/oauth2/token")
 	data := url.Values{}
 	data.Add("client_id", clientID)
 	data.Add("client_secret", clientSecret)
@@ -113,7 +121,7 @@ func (c *Client) GetUsers(ctx context.Context) ([]User, error) {
 	var allUsers []User
 	offset := defaultOffset
 	totalReturned := 0
-	usersUrl := fmt.Sprint(baseUrl, "/2.0/users")
+	usersUrl := fmt.Sprint(c.baseURL, "/2.0/users")
 
 	var res struct {
 		paginationData
@@ -149,7 +157,7 @@ func (c *Client) GetGroups(ctx context.Context) ([]Group, error) {
 	var allGroups []Group
 	offset := defaultOffset
 	totalReturned := 0
-	usersUrl := fmt.Sprint(baseUrl, "/2.0/groups")
+	usersUrl := fmt.Sprint(c.baseURL, "/2.0/groups")
 
 	var res struct {
 		paginationData
@@ -185,7 +193,7 @@ func (c *Client) GetGroupMemberships(ctx context.Context, groupId string) ([]Gro
 	var allGroupMemberships []GroupMembership
 	offset := defaultOffset
 	totalReturned := 0
-	usersUrl := fmt.Sprintf("%s/2.0/groups/%s/memberships", baseUrl, groupId)
+	usersUrl := fmt.Sprintf("%s/2.0/groups/%s/memberships", c.baseURL, groupId)
 
 	var res struct {
 		paginationData
@@ -216,7 +224,7 @@ func (c *Client) GetGroupMemberships(ctx context.Context, groupId string) ([]Gro
 
 // GetCurrentUserWithEnterprise returns current user with enterprise data.
 func (c *Client) GetCurrentUserWithEnterprise(ctx context.Context) (User, error) {
-	usersUrl := fmt.Sprint(baseUrl, "/2.0/users/me")
+	usersUrl := fmt.Sprint(c.baseURL, "/2.0/users/me")
 	params := url.Values{}
 	params.Set("fields", "enterprise,role,name")
 
@@ -233,7 +241,7 @@ func (c *Client) GetCurrentUserWithEnterprise(ctx context.Context) (User, error)
 
 // GetGroup returns Box group details.
 func (c *Client) GetGroup(ctx context.Context, groupId string) (Group, error) {
-	usersUrl := fmt.Sprint(baseUrl, "/2.0/groups/", groupId)
+	usersUrl := fmt.Sprint(c.baseURL, "/2.0/groups/", groupId)
 
 	var res Group
 	params := url.Values{}

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,6 +7,7 @@ type Box struct {
 	BoxClientId string `mapstructure:"box-client-id"`
 	BoxClientSecret string `mapstructure:"box-client-secret"`
 	EnterpriseId string `mapstructure:"enterprise-id"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Box) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Box API URL (for testing or enterprise deployments)"),
+		field.WithHidden(true),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,10 @@ var (
 		field.WithDescription("ID of your Box enterprise."),
 		field.WithRequired(true),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Box API URL (for testing or enterprise deployments)"),
+	)
 )
 
 //go:generate go run ./gen
@@ -30,4 +34,5 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	ClientID,
 	ClientSecret,
 	EnterpriseID,
+	BaseURLField,
 })

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Box API URL (for testing or enterprise deployments)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	resourceTypeUser = &v2.ResourceType{
-		Id:          "user",
+		Id:          user,
 		DisplayName: "User",
 		Traits: []v2.ResourceType_Trait{
 			v2.ResourceType_TRAIT_USER,
@@ -74,7 +74,7 @@ func (b *Box) Validate(ctx context.Context) (annotations.Annotations, error) {
 		return nil, fmt.Errorf("box-connector: failed to authenticate: %w", err)
 	}
 
-	if currentUser.Role != "admin" {
+	if currentUser.Role != admin {
 		return nil, fmt.Errorf("box-connector: user is not an admin")
 	}
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -45,19 +45,19 @@ type Box struct {
 	client *box.Client
 }
 
-func New(ctx context.Context, clientId string, clientSecret string, enterpriseId string) (*Box, error) {
+func New(ctx context.Context, clientId string, clientSecret string, enterpriseId string, baseURL string) (*Box, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := box.RequestAccessToken(ctx, clientId, clientSecret, enterpriseId)
+	token, err := box.RequestAccessToken(ctx, clientId, clientSecret, enterpriseId, baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("box-connector: failed to get token: %w", err)
 	}
 
 	return &Box{
-		client: box.NewClient(httpClient, token),
+		client: box.NewClient(httpClient, token, baseURL),
 	}, nil
 }
 

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -16,6 +16,7 @@ import (
 const (
 	member = "member"
 	admin  = "admin"
+	user   = "user"
 )
 
 type groupResourceType struct {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -23,9 +23,9 @@ func (o *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 }
 
 var roles = map[string]string{
-	"admin":   "admin",
+	admin:     admin,
 	"coadmin": "co-admin",
-	"user":    "user",
+	user:      user,
 }
 
 // Create a new connector resource for a Box role.


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-box/main.go,pkg/box/client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-box --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable Box API base URL
  * Users can now override the default API endpoint through configuration settings
  * Default endpoint behavior is preserved when no custom URL is specified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->